### PR TITLE
Throw an error if the signal of the route does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ var router = function (controller, routes, options) {
 
     var signal = controller.signals[routes[route]];
 
+    if(!signal) {
+      throw new Error('Cerebral router - The signal "' + routes[route] + '" for the route "' + route + '" does not exist.');
+    }
+
     // In case already wrapped
     if (signal.signal) {
       signal = signal.signal;


### PR DESCRIPTION
This can help for faster debug when the signal is not defined
Currently you will just see "signal.signal is not defined" so not really helpfull